### PR TITLE
添加 Shadowrocket 显示分组名称

### DIFF
--- a/cloudflare/src/routes/api.ts
+++ b/cloudflare/src/routes/api.ts
@@ -387,14 +387,14 @@ apiRoutes.post("/preview/collection", async (c) => {
 apiRoutes.get("/link/source/:name", async (c) => {
   const sub = await getSource(c.env, c.req.param("name"));
   if (!sub) return failed(c, "Source not found", 404);
-  const link = buildDownloadLink(c, "source", sub.id);
+  const link = buildDownloadLink(c, "source", sub.id, sub.name);
   if (!link) return failed(c, "Unsupported target", 400);
   return success(c, link);
 });
 apiRoutes.get("/link/collection/:name", async (c) => {
   const collection = await getCollection(c.env, c.req.param("name"));
   if (!collection) return failed(c, "Collection not found", 404);
-  const link = buildDownloadLink(c, "collection", collection.id);
+  const link = buildDownloadLink(c, "collection", collection.id, collection.name);
   if (!link) return failed(c, "Unsupported target", 400);
   return success(c, link);
 });
@@ -598,7 +598,7 @@ function toSubscriptionCollection(input: JsonMap): SubscriptionCollection {
   };
 }
 
-function buildDownloadLink(c: ApiContext, kind: "source" | "collection", id: string) {
+function buildDownloadLink(c: ApiContext, kind: "source" | "collection", id: string, name: string) {
   const rawTarget = c.req.query("target");
   const target = normalizeDownloadTarget(rawTarget);
   if (rawTarget && !target) return undefined;
@@ -609,7 +609,20 @@ function buildDownloadLink(c: ApiContext, kind: "source" | "collection", id: str
     const value = c.req.query(key);
     if (value) url.searchParams.set(key, value);
   }
-  return { url: url.toString(), target: target || "auto", tokenIncluded: Boolean(c.env.SUB_STORE_PUBLIC_DOWNLOAD_TOKEN) };
+  const subscriptionUrl = url.toString();
+  return {
+    url: target === "shadowrocket" ? buildShadowrocketLink(subscriptionUrl, name) : subscriptionUrl,
+    subscriptionUrl,
+    target: target || "auto",
+    tokenIncluded: Boolean(c.env.SUB_STORE_PUBLIC_DOWNLOAD_TOKEN),
+  };
+}
+
+function buildShadowrocketLink(subscriptionUrl: string, remark: string) {
+  const bytes = new TextEncoder().encode(subscriptionUrl);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return `sub://${btoa(binary)}#${encodeURIComponent(remark || "订阅")}`;
 }
 
 function getPublicBaseUrl(c: ApiContext) {

--- a/cloudflare/test/worker.test.ts
+++ b/cloudflare/test/worker.test.ts
@@ -279,7 +279,7 @@ describe("Worker and D1 integration", () => {
         }],
         collections: [{
           id: "test-collection",
-          name: "Test Collection",
+          name: "测试集合",
           sourceIds: ["test-local"],
           templateId: "test-template",
           enabled: true,
@@ -300,6 +300,16 @@ describe("Worker and D1 integration", () => {
     expect(download.status).toBe(200);
     expect(download.headers.get("content-type")).toContain("text/yaml");
     expect(await download.text()).toContain("Test Node");
+
+    const shadowrocketLinkResponse = await workerRequest(
+      "/api/link/collection/test-collection?target=shadowrocket",
+    );
+    const shadowrocketLink = String(getPath(await jsonObject(shadowrocketLinkResponse), "data", "url"));
+    const [encodedUrl, encodedRemark] = shadowrocketLink.split("#");
+    expect(atob(encodedUrl.slice("sub://".length))).toBe(
+      `https://downloads.example.com/download/collection/test-collection/shadowrocket?token=${DOWNLOAD_TOKEN}`,
+    );
+    expect(decodeURIComponent(encodedRemark)).toBe("测试集合");
   });
 
   it("rejects oversized API bodies", async () => {

--- a/frontend/src/components/PreviewPanel.vue
+++ b/frontend/src/components/PreviewPanel.vue
@@ -140,7 +140,7 @@
   const targetOpen = async (path: PlatformPath) => {
     const pendingWindow = window.open('about:blank', '_blank');
     const realUrl = await getRealUrl(path);
-    const nextUrl = appearanceSetting.value.displayPreviewInWebPage && path !== 'shadowrocket'
+    const nextUrl = appearanceSetting.value.displayPreviewInWebPage
         ? buildUrlWithQuery('/preview', {
             url: realUrl,
             name: displayName || name,

--- a/frontend/src/components/PreviewPanel.vue
+++ b/frontend/src/components/PreviewPanel.vue
@@ -140,7 +140,7 @@
   const targetOpen = async (path: PlatformPath) => {
     const pendingWindow = window.open('about:blank', '_blank');
     const realUrl = await getRealUrl(path);
-    const nextUrl = appearanceSetting.value.displayPreviewInWebPage
+    const nextUrl = appearanceSetting.value.displayPreviewInWebPage && path !== 'shadowrocket'
         ? buildUrlWithQuery('/preview', {
             url: realUrl,
             name: displayName || name,


### PR DESCRIPTION
主要修改：
Shadowrocket 复制链接使用：
sub://Base64(完整订阅地址)#URL编码后的名称

名称取 Source/Collection 自定义名称，支持中文。

保留普通订阅地址 subscriptionUrl。

新增中文备注与完整下载地址的集成测试。

其他客户端行为不变。